### PR TITLE
Add outbound throttling

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
@@ -230,6 +230,7 @@ public final class Constants {
     public static final String HTTP2_TARGET_HANDLER = "http2TargetHandler";
     public static final String TARGET_HANDLER = "targetHandler";
     public static final String HTTP2_TIMEOUT_HANDLER = "Http2TimeoutHandler";
+    public static final String OUTBOUND_THROTTLING_HANDLER = "outboundThrottlingHandler";
     public static final String HTTP2_UPGRADE_HANDLER = "Http2UpgradeHandler";
     public static final String HTTP2_TO_HTTP_FALLBACK_HANDLER = "Http2ToHttpFallbackHandler";
     public static final String DECOMPRESSOR_HANDLER = "deCompressor";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -26,11 +26,14 @@ import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.HttpConnectorListener;
 import org.wso2.transport.http.netty.contract.config.ChunkConfig;
 import org.wso2.transport.http.netty.contract.config.KeepAliveConfig;
+import org.wso2.transport.http.netty.contractimpl.common.OutboundThrottlingHandler;
+import org.wso2.transport.http.netty.contractimpl.common.Util;
 import org.wso2.transport.http.netty.contractimpl.common.states.MessageStateContext;
 import org.wso2.transport.http.netty.contractimpl.listener.RequestDataHolder;
 import org.wso2.transport.http.netty.contractimpl.listener.SourceHandler;
 import org.wso2.transport.http.netty.internal.HandlerExecutor;
 import org.wso2.transport.http.netty.internal.HttpTransportContextHolder;
+import org.wso2.transport.http.netty.message.DefaultOutboundThrottlingListener;
 import org.wso2.transport.http.netty.message.Http2PushPromise;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 
@@ -70,22 +73,31 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     @Override
     public void onMessage(HttpCarbonMessage outboundResponseMsg) {
         sourceContext.channel().eventLoop().execute(() -> {
-
+            OutboundThrottlingHandler outboundThrottlingHandler = Util.getOutBoundThrottlingHandler(sourceContext);
+            if (outboundThrottlingHandler != null) {
+                outboundThrottlingHandler.getOutboundThrottlingObservable().setListener(
+                        new DefaultOutboundThrottlingListener(sourceContext));
+            }
             if (handlerExecutor != null) {
                 handlerExecutor.executeAtSourceResponseReceiving(outboundResponseMsg);
             }
 
-            outboundResponseMsg.getHttpContentAsync().setMessageListener(httpContent ->
-                    this.sourceContext.channel().eventLoop().execute(() -> {
-                        try {
-                            writeOutboundResponse(outboundResponseMsg, httpContent);
-                        } catch (Exception exception) {
-                            String errorMsg = "Failed to send the outbound response : "
-                                    + exception.getMessage().toLowerCase(Locale.ENGLISH);
-                            LOG.error(errorMsg, exception);
-                            inboundRequestMsg.getHttpOutboundRespStatusFuture().notifyHttpListener(exception);
-                        }
-                    }));
+            outboundResponseMsg.getHttpContentAsync().setMessageListener(httpContent -> {
+                if (outboundThrottlingHandler != null) {
+                    //This is in the Ballerina thread
+                    outboundThrottlingHandler.getOutboundThrottlingObservable().notifyAcquire();
+                }
+                this.sourceContext.channel().eventLoop().execute(() -> {
+                    try {
+                        writeOutboundResponse(outboundResponseMsg, httpContent);
+                    } catch (Exception exception) {
+                        String errorMsg = "Failed to send the outbound response : "
+                                + exception.getMessage().toLowerCase(Locale.ENGLISH);
+                        LOG.error(errorMsg, exception);
+                        inboundRequestMsg.getHttpOutboundRespStatusFuture().notifyHttpListener(exception);
+                    }
+                });
+            });
         });
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/OutboundThrottlingHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/OutboundThrottlingHandler.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.contractimpl.common;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.wso2.transport.http.netty.message.DefaultOutboundThrottlingObservable;
+import org.wso2.transport.http.netty.message.OutboundThrottlingObservable;
+
+/**
+ * The class for handling outbound throttling.
+ * The class overrides the channelWritabilityChanged method to check the writability of the channel which is needed
+ * for outbound throttling.
+ */
+public class OutboundThrottlingHandler extends ChannelInboundHandlerAdapter {
+
+    private final OutboundThrottlingObservable outboundThrottlingObservable = new DefaultOutboundThrottlingObservable();
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) {
+        if (ctx.channel().isWritable()) {
+           outboundThrottlingObservable.notifyRelease();
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        outboundThrottlingObservable.notifyRelease();
+        ctx.fireChannelInactive();
+    }
+
+    public OutboundThrottlingObservable getOutboundThrottlingObservable() {
+        return outboundThrottlingObservable;
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
@@ -809,4 +809,16 @@ public class Util {
         sslParams.setEndpointIdentificationAlgorithm(Constants.HTTPS_SCHEME);
         sslEngine.setSSLParameters(sslParams);
     }
+
+    /**
+     * Use this method to get the {@link OutboundThrottlingHandler} in the pipeline. This requires a
+     * {@link ChannelHandlerContext} of a handler in the pipeline.
+     *
+     * @param channelContext the channelContext which will be used to obtain the {@link OutboundThrottlingHandler}
+     *                       in the pipeline.
+     */
+    public static OutboundThrottlingHandler getOutBoundThrottlingHandler(ChannelHandlerContext channelContext) {
+        return (OutboundThrottlingHandler) channelContext.pipeline().get(Constants.OUTBOUND_THROTTLING_HANDLER);
+
+    }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
@@ -46,6 +46,7 @@ import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contract.config.ChunkConfig;
 import org.wso2.transport.http.netty.contract.config.KeepAliveConfig;
 import org.wso2.transport.http.netty.contract.config.RequestSizeValidationConfig;
+import org.wso2.transport.http.netty.contractimpl.common.OutboundThrottlingHandler;
 import org.wso2.transport.http.netty.contractimpl.common.certificatevalidation.CertificateVerificationException;
 import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLConfig;
 import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLHandlerFactory;
@@ -207,6 +208,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
 
         serverPipeline.addLast(Constants.WEBSOCKET_SERVER_HANDSHAKE_HANDLER,
                          new WebSocketServerHandshakeHandler(this.serverConnectorFuture, this.interfaceId));
+        serverPipeline.addLast(Constants.OUTBOUND_THROTTLING_HANDLER, new OutboundThrottlingHandler());
         serverPipeline.addLast(Constants.HTTP_SOURCE_HANDLER,
                                new SourceHandler(this.serverConnectorFuture, this.interfaceId, this.chunkConfig,
                                                  keepAliveConfig, this.serverName, this.allChannels,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/WebSocketServerHandshakeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/WebSocketServerHandshakeHandler.java
@@ -77,6 +77,9 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
                         LOG.debug("Upgrading the connection from Http to WebSocket for channel : {}", ctx.channel());
                     }
                     ChannelPipeline pipeline = ctx.pipeline();
+                    if (pipeline.get(Constants.OUTBOUND_THROTTLING_HANDLER) != null) {
+                        pipeline.remove(Constants.OUTBOUND_THROTTLING_HANDLER);
+                    }
                     pipeline.remove(Constants.HTTP_SOURCE_HANDLER);
                     ChannelHandlerContext decoderCtx = pipeline.context(HttpRequestDecoder.class);
                     pipeline.addAfter(decoderCtx.name(), HTTP_OBJECT_AGGREGATOR,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
@@ -44,6 +44,7 @@ import org.wso2.transport.http.netty.contract.config.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contractimpl.common.FrameLogger;
 import org.wso2.transport.http.netty.contractimpl.common.HttpRoute;
+import org.wso2.transport.http.netty.contractimpl.common.OutboundThrottlingHandler;
 import org.wso2.transport.http.netty.contractimpl.common.Util;
 import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLConfig;
 import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLHandlerFactory;
@@ -235,6 +236,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
     public void configureHttpPipeline(ChannelPipeline pipeline, TargetHandler targetHandler) {
         pipeline.addLast(Constants.HTTP_CLIENT_CODEC, new HttpClientCodec());
         addCommonHandlers(pipeline);
+        pipeline.addLast(Constants.OUTBOUND_THROTTLING_HANDLER, new OutboundThrottlingHandler());
         pipeline.addLast(Constants.TARGET_HANDLER, targetHandler);
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/TargetHandler.java
@@ -59,6 +59,12 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     private HandlerExecutor handlerExecutor;
     private KeepAliveConfig keepAliveConfig;
     private boolean idleTimeoutTriggered;
+    private ChannelHandlerContext context;
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) {
+        context = ctx;
+    }
 
     @SuppressWarnings("unchecked")
     @Override
@@ -231,5 +237,14 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
 
     public ConnectionManager getConnectionManager() {
         return connectionManager;
+    }
+
+    /**
+     * Gets the {@link ChannelHandlerContext} of the {@link TargetHandler}.
+     *
+     * @return the {@link ChannelHandlerContext} of this handler.
+     */
+    public ChannelHandlerContext getContext() {
+        return context;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/channel/TargetChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/channel/TargetChannel.java
@@ -27,6 +27,8 @@ import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.contract.config.ChunkConfig;
 import org.wso2.transport.http.netty.contract.config.ForwardedExtensionConfig;
 import org.wso2.transport.http.netty.contractimpl.common.HttpRoute;
+import org.wso2.transport.http.netty.contractimpl.common.OutboundThrottlingHandler;
+import org.wso2.transport.http.netty.contractimpl.common.Util;
 import org.wso2.transport.http.netty.contractimpl.common.states.MessageStateContext;
 import org.wso2.transport.http.netty.contractimpl.listener.HttpTraceLoggingHandler;
 import org.wso2.transport.http.netty.contractimpl.listener.SourceHandler;
@@ -39,7 +41,9 @@ import org.wso2.transport.http.netty.contractimpl.sender.http2.Http2ClientChanne
 import org.wso2.transport.http.netty.contractimpl.sender.states.SendingHeaders;
 import org.wso2.transport.http.netty.internal.HandlerExecutor;
 import org.wso2.transport.http.netty.internal.HttpTransportContextHolder;
+import org.wso2.transport.http.netty.message.DefaultOutboundThrottlingListener;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
+import org.wso2.transport.http.netty.message.PassthroughOutboundThrottlingListener;
 
 import java.net.InetSocketAddress;
 import java.util.Locale;
@@ -180,6 +184,18 @@ public class TargetChannel {
     }
 
     public void writeContent(HttpCarbonMessage httpOutboundRequest) {
+        OutboundThrottlingHandler outboundThrottlingHandler = Util.getOutBoundThrottlingHandler(
+                targetHandler.getContext());
+        if (outboundThrottlingHandler != null) {
+            if (httpOutboundRequest.isPassthrough()) {
+                outboundThrottlingHandler.getOutboundThrottlingObservable().setListener(
+                        new PassthroughOutboundThrottlingListener(httpOutboundRequest.getSourceContext(),
+                                                                  targetHandler.getContext()));
+            } else {
+                outboundThrottlingHandler.getOutboundThrottlingObservable().setListener(
+                        new DefaultOutboundThrottlingListener(targetHandler.getContext()));
+            }
+        }
         if (handlerExecutor != null) {
             handlerExecutor.executeAtTargetRequestReceiving(httpOutboundRequest);
         }
@@ -194,17 +210,22 @@ public class TargetChannel {
         httpOutboundRequest.getMessageStateContext()
                 .setSenderState(new SendingHeaders(messageStateContext, this, httpVersion, chunkConfig,
                                                    httpInboundResponseFuture));
-        httpOutboundRequest.getHttpContentAsync().setMessageListener((httpContent ->
-                this.channel.eventLoop().execute(() -> {
-                    try {
-                        writeOutboundRequest(httpOutboundRequest, httpContent);
-                    } catch (Exception exception) {
-                        String errorMsg = "Failed to send the request : "
-                                + exception.getMessage().toLowerCase(Locale.ENGLISH);
-                        LOG.error(errorMsg, exception);
-                        this.targetHandler.getHttpResponseFuture().notifyHttpListener(exception);
-                    }
-                })));
+        httpOutboundRequest.getHttpContentAsync().setMessageListener((httpContent -> {
+            if (outboundThrottlingHandler != null) {
+                //This is in the Ballerina thread
+                outboundThrottlingHandler.getOutboundThrottlingObservable().notifyAcquire();
+            }
+            this.channel.eventLoop().execute(() -> {
+                try {
+                    writeOutboundRequest(httpOutboundRequest, httpContent);
+                } catch (Exception exception) {
+                    String errorMsg = "Failed to send the request : "
+                            + exception.getMessage().toLowerCase(Locale.ENGLISH);
+                    LOG.error(errorMsg, exception);
+                    this.targetHandler.getHttpResponseFuture().notifyHttpListener(exception);
+                }
+            });
+        }));
     }
 
     private void writeOutboundRequest(HttpCarbonMessage httpOutboundRequest, HttpContent httpContent) throws Exception {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultListener.java
@@ -65,4 +65,9 @@ public class DefaultListener implements Listener {
             this.ctx.channel().read();
         }
     }
+
+    @Override
+    public void resumeReadInterest() {
+        ctx.channel().config().setAutoRead(true);
+    }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultObservable.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultObservable.java
@@ -34,7 +34,8 @@ public class DefaultObservable implements Observable {
 
     @Override
     public void removeListener() {
-        this.listener = null;
+        listener.resumeReadInterest();
+        listener = null;
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultOutboundThrottlingListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultOutboundThrottlingListener.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.message;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * Default implementation of the {@link OutboundThrottlingListener}.
+ */
+public class DefaultOutboundThrottlingListener implements OutboundThrottlingListener {
+    private static final Logger LOG = LoggerFactory.getLogger(HttpMessageDataStreamer.class);
+
+    private Semaphore semaphore;
+    private Channel channel;
+
+    /**
+     * Creates the semaphore and sets the source or target channel.
+     *
+     * @param context The {@link org.wso2.transport.http.netty.contractimpl.listener.SourceHandler} context for
+     *                outbound response and the
+     *                {@link org.wso2.transport.http.netty.contractimpl.sender.TargetHandler} context for the
+     *                outbound request.
+     */
+    public DefaultOutboundThrottlingListener(ChannelHandlerContext context) {
+        this.channel = context.channel();
+        this.semaphore = new Semaphore(0);
+    }
+
+    @Override
+    public void onAcquire() {
+        if (!channel.isWritable() && channel.isActive()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Semaphore acquired for channel {}.", channel.id());
+            }
+            try {
+                semaphore.acquire();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override
+    public void onRelease() {
+        LOG.debug("Semaphore released for channel {}.", channel.id());
+        semaphore.release();
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultOutboundThrottlingObservable.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultOutboundThrottlingObservable.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.message;
+
+/**
+ * Default implementation of the {@link OutboundThrottlingObservable}.
+ */
+public class DefaultOutboundThrottlingObservable implements OutboundThrottlingObservable {
+
+    private OutboundThrottlingListener listener;
+
+    @Override
+    public void setListener(OutboundThrottlingListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void removeListener() {
+        listener.onRelease();
+        this.listener = null;
+    }
+
+    @Override
+    public void notifyAcquire() {
+        if (listener != null) {
+            listener.onAcquire();
+        }
+    }
+
+    @Override
+    public void notifyRelease() {
+        if (listener != null) {
+            listener.onRelease();
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
@@ -66,6 +66,7 @@ public class HttpCarbonMessage {
     private HttpPipeliningFuture pipeliningFuture;
     private boolean keepAlive;
     private boolean pipeliningNeeded;
+    private boolean passthrough = false;
 
     public HttpCarbonMessage(HttpMessage httpMessage, Listener contentListener) {
         this.httpMessage = httpMessage;
@@ -444,5 +445,29 @@ public class HttpCarbonMessage {
 
     public void setPipeliningFuture(HttpPipeliningFuture pipeliningFuture) {
         this.pipeliningFuture = pipeliningFuture;
+    }
+
+    /**
+     * @return true if it is a passthrough(when message body is not built).
+     */
+    public boolean isPassthrough() {
+        return passthrough;
+    }
+
+    /**
+     * This value is to be set when the message is to be sent to the consumer without building/processing the message
+     * in the application layer.
+     *
+     * @param passthrough if the message is a passthrough.
+     */
+    public void setPassthrough(boolean passthrough) {
+        this.passthrough = passthrough;
+    }
+
+    /**
+     * Removes the content listener that is set for handling Inbound throttling.
+     */
+    public void removeContentListener() {
+        contentObservable.removeListener();
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/MessageFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/MessageFuture.java
@@ -47,6 +47,11 @@ public class MessageFuture {
                     return;
                 }
             }
+
+            //Removes Inbound throttling listener during passthrough so that only outbound throttling would be present.
+            if (httpCarbonMessage.isPassthrough()) {
+                httpCarbonMessage.removeContentListener();
+            }
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/OutboundThrottlingListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/OutboundThrottlingListener.java
@@ -18,27 +18,18 @@
 
 package org.wso2.transport.http.netty.message;
 
-import io.netty.handler.codec.http.HttpContent;
-
 /**
- * Get notified upon receiving new messages.
+ * Gets notified to acquire or release during Outbound throttling.
  */
-public interface Listener {
+public interface OutboundThrottlingListener {
 
     /**
-     * Get notified when content are added to the message.
-     * @param httpContent of the message
+     * Get notified to start throttling.
      */
-    void onAdd(HttpContent httpContent);
+    void onAcquire();
 
     /**
-     * Get notified when content is removed from the the message.
-     * @param httpContent of the message
+     * Get notified to release throttling.
      */
-    void onRemove(HttpContent httpContent);
-
-    /**
-     * Since the listener removes readInterest this method resumes it if required.
-     */
-    void resumeReadInterest();
+    void onRelease();
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/OutboundThrottlingObservable.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/OutboundThrottlingObservable.java
@@ -18,27 +18,29 @@
 
 package org.wso2.transport.http.netty.message;
 
-import io.netty.handler.codec.http.HttpContent;
-
 /**
- * Get notified upon receiving new messages.
+ * Allows listeners to register and get notified.
  */
-public interface Listener {
+public interface OutboundThrottlingObservable {
 
     /**
-     * Get notified when content are added to the message.
-     * @param httpContent of the message
+     * Set listener interested for message events.
+     * @param listener for message
      */
-    void onAdd(HttpContent httpContent);
+    void setListener(OutboundThrottlingListener listener);
 
     /**
-     * Get notified when content is removed from the the message.
-     * @param httpContent of the message
+     * Remove listener from the observable.
      */
-    void onRemove(HttpContent httpContent);
+    void removeListener();
 
     /**
-     * Since the listener removes readInterest this method resumes it if required.
+     * Notify to start throttling.
      */
-    void resumeReadInterest();
+    void notifyAcquire();
+
+    /**
+     * Notify to release throttling.
+     */
+    void notifyRelease();
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/PassthroughOutboundThrottlingListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/PassthroughOutboundThrottlingListener.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.message;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of the {@link OutboundThrottlingListener}.
+ */
+public class PassthroughOutboundThrottlingListener implements OutboundThrottlingListener {
+    private static final Logger LOG = LoggerFactory.getLogger(HttpMessageDataStreamer.class);
+
+    private Channel sourceChannel;
+    private Channel targetChannel;
+
+    /**
+     * Sets the source and target channels.
+     *
+     * @param sourceContext This will be used to block and resume read interest of the source channel.
+     * @param targetContext This will be used to check the writability of the target channel.
+     */
+    public PassthroughOutboundThrottlingListener(ChannelHandlerContext sourceContext,
+                                                 ChannelHandlerContext targetContext) {
+        sourceChannel = sourceContext.channel();
+        targetChannel = targetContext.channel();
+    }
+
+    @Override
+    public void onAcquire() {
+        if (!targetChannel.isWritable()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Read disabled for sourceChannel {}", sourceChannel.id());
+            }
+            sourceChannel.config().setAutoRead(false);
+        }
+    }
+
+    @Override
+    public void onRelease() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Read enabled for sourceChannel {}", sourceChannel.id());
+        }
+        sourceChannel.config().setAutoRead(true);
+    }
+}


### PR DESCRIPTION
## Purpose
> Client can go OOM if the server is slow during a send operation because of data collecting in the netty buffer. Similarly server can go OOM if the client is slow during a respond operation. Outbound throttling fixes this issue.

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/8767