### PR TITLE
First Add outbound throttling

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
@@ -229,6 +229,7 @@ public final class Constants {
     public static final String CONNECTION_HANDLER = "connectionHandler";
     public static final String HTTP2_TARGET_HANDLER = "http2TargetHandler";
     public static final String TARGET_HANDLER = "targetHandler";
+    public static final String OUTBOUND_THROTTLING_HANDLER = "outboundThrottlingHandler";
     public static final String HTTP2_TIMEOUT_HANDLER = "Http2TimeoutHandler";
     public static final String HTTP2_UPGRADE_HANDLER = "Http2UpgradeHandler";
     public static final String HTTP2_TO_HTTP_FALLBACK_HANDLER = "Http2ToHttpFallbackHandler";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/OutboundThrottlingHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/OutboundThrottlingHandler.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.contractimpl.common;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.transport.http.netty.message.HttpCarbonMessage;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * The class for handling outbound throttling.
+ * The class overrides the channelWritabilityChanged method to check the writability of the channel which is needed
+ * for outbound throttling. Further if this handler is not in the pipeline then the writingBlocker semaphore will not
+ * be set in the carbonMessage.
+ */
+public class OutboundThrottlingHandler extends ChannelInboundHandlerAdapter {
+    private static final Logger LOG = LoggerFactory.getLogger(OutboundThrottlingHandler.class);
+
+    private HttpCarbonMessage httpCarbonMessage = null;
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) {
+        if (ctx.channel().isWritable() && httpCarbonMessage != null) {
+            if (!httpCarbonMessage.isPassthrough()) {
+                releaseWritingBlocker();
+            } else {
+                while (!httpCarbonMessage.isEmpty() && ctx.channel().isWritable()) {
+                    httpCarbonMessage.notifyListener();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        if (httpCarbonMessage != null && !httpCarbonMessage.isPassthrough()) {
+            releaseWritingBlocker();
+        }
+        ctx.fireChannelInactive();
+    }
+
+    /**
+     * Sets the {@link HttpCarbonMessage} in the pipeline and creates a new semaphore the the message.
+     *
+     * @param httpCarbonMessage the {@link HttpCarbonMessage} in the pipeline
+     */
+    public void setHttpCarbonMessage(HttpCarbonMessage httpCarbonMessage) {
+        this.httpCarbonMessage = httpCarbonMessage;
+        httpCarbonMessage.setWritingBlocker(new Semaphore(0));
+    }
+
+    /**
+     * Releases the semaphore in the httpCarbonMessage.
+     */
+    private void releaseWritingBlocker() {
+        httpCarbonMessage.getWritingBlocker().release();
+        if (LOG.isDebugEnabled() && httpCarbonMessage.getChannelContext() != null) {
+            LOG.debug("Semaphore released for channel {}.", httpCarbonMessage.getChannelContext().channel().id());
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
@@ -809,4 +809,23 @@ public class Util {
         sslParams.setEndpointIdentificationAlgorithm(Constants.HTTPS_SCHEME);
         sslEngine.setSSLParameters(sslParams);
     }
+
+    /**
+     * Use this method to set the {@link HttpCarbonMessage} to the {@link OutboundThrottlingHandler}
+     * in the pipeline. This requires a {@link ChannelHandlerContext} of a handler in the pipeline.
+     *
+     * @param httpCarbonMessage the carbonMessage to be set to the {@link OutboundThrottlingHandler}
+     * @param channelContext    the channelContext which will be used to obtain the {@link OutboundThrottlingHandler}
+     *                          in the pipeline.
+     */
+    public static void setHttpCarbonMessageToOutboundThrottlingHandler(HttpCarbonMessage httpCarbonMessage,
+                                                                       ChannelHandlerContext channelContext) {
+        if (channelContext != null) {
+            OutboundThrottlingHandler throttlingHandler =
+                    (OutboundThrottlingHandler) channelContext.pipeline().get(Constants.OUTBOUND_THROTTLING_HANDLER);
+            if (throttlingHandler != null) {
+                throttlingHandler.setHttpCarbonMessage(httpCarbonMessage);
+            }
+        }
+    }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
@@ -46,6 +46,7 @@ import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contract.config.ChunkConfig;
 import org.wso2.transport.http.netty.contract.config.KeepAliveConfig;
 import org.wso2.transport.http.netty.contract.config.RequestSizeValidationConfig;
+import org.wso2.transport.http.netty.contractimpl.common.OutboundThrottlingHandler;
 import org.wso2.transport.http.netty.contractimpl.common.certificatevalidation.CertificateVerificationException;
 import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLConfig;
 import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLHandlerFactory;
@@ -207,6 +208,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
 
         serverPipeline.addLast(Constants.WEBSOCKET_SERVER_HANDSHAKE_HANDLER,
                          new WebSocketServerHandshakeHandler(this.serverConnectorFuture, this.interfaceId));
+        serverPipeline.addLast(Constants.OUTBOUND_THROTTLING_HANDLER, new OutboundThrottlingHandler());
         serverPipeline.addLast(Constants.HTTP_SOURCE_HANDLER,
                                new SourceHandler(this.serverConnectorFuture, this.interfaceId, this.chunkConfig,
                                                  keepAliveConfig, this.serverName, this.allChannels,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
@@ -184,7 +184,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         if (ctx != null && ctx.channel().isActive()) {
             ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
         }
-        LOG.warn("Exception occurred in SourceHandler : {}", cause.getMessage());
+        LOG.warn("Exception occurred in SourceHandler : {}", cause);
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/WebSocketServerHandshakeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/WebSocketServerHandshakeHandler.java
@@ -77,6 +77,9 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
                         LOG.debug("Upgrading the connection from Http to WebSocket for channel : {}", ctx.channel());
                     }
                     ChannelPipeline pipeline = ctx.pipeline();
+                    if (pipeline.get(Constants.OUTBOUND_THROTTLING_HANDLER) != null) {
+                        pipeline.remove(Constants.OUTBOUND_THROTTLING_HANDLER);
+                    }
                     pipeline.remove(Constants.HTTP_SOURCE_HANDLER);
                     ChannelHandlerContext decoderCtx = pipeline.context(HttpRequestDecoder.class);
                     pipeline.addAfter(decoderCtx.name(), HTTP_OBJECT_AGGREGATOR,
@@ -121,7 +124,7 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         ctx.writeAndFlush(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR))
                 .addListener(ChannelFutureListener.CLOSE);
-        LOG.error("Error during WebSocket server handshake", cause);
+        LOG.error("Error occurred: ", cause);
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/ConnectionAvailabilityFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/ConnectionAvailabilityFuture.java
@@ -44,7 +44,7 @@ public class ConnectionAvailabilityFuture {
         socketAvailabilityFuture.addListener(new ChannelFutureListener() {
 
             @Override
-            public void operationComplete(ChannelFuture channelFuture) throws Exception {
+            public void operationComplete(ChannelFuture channelFuture) {
                 if (isValidChannel(channelFuture)) {
                     socketAvailable = true;
                     if (listener != null && !isSSLEnabled) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
@@ -44,6 +44,7 @@ import org.wso2.transport.http.netty.contract.config.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contractimpl.common.FrameLogger;
 import org.wso2.transport.http.netty.contractimpl.common.HttpRoute;
+import org.wso2.transport.http.netty.contractimpl.common.OutboundThrottlingHandler;
 import org.wso2.transport.http.netty.contractimpl.common.Util;
 import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLConfig;
 import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLHandlerFactory;
@@ -235,6 +236,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
     public void configureHttpPipeline(ChannelPipeline pipeline, TargetHandler targetHandler) {
         pipeline.addLast(Constants.HTTP_CLIENT_CODEC, new HttpClientCodec());
         addCommonHandlers(pipeline);
+        pipeline.addLast(Constants.OUTBOUND_THROTTLING_HANDLER, new OutboundThrottlingHandler());
         pipeline.addLast(Constants.TARGET_HANDLER, targetHandler);
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/TargetHandler.java
@@ -60,6 +60,13 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     private HandlerExecutor handlerExecutor;
     private KeepAliveConfig keepAliveConfig;
     private boolean idleTimeoutTriggered;
+    private ChannelHandlerContext context;
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        context = ctx;
+        super.handlerAdded(ctx);
+    }
 
     @SuppressWarnings("unchecked")
     @Override
@@ -235,5 +242,14 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
 
     public ConnectionManager getConnectionManager() {
         return connectionManager;
+    }
+
+    /**
+     * Gets the {@link ChannelHandlerContext} of the {@link TargetHandler}.
+     *
+     * @return the {@link ChannelHandlerContext} of this handler.
+     */
+    public ChannelHandlerContext getContext() {
+        return context;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/MessageFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/MessageFuture.java
@@ -19,7 +19,6 @@
 package org.wso2.transport.http.netty.message;
 
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,17 +39,12 @@ public class MessageFuture {
         synchronized (httpCarbonMessage) {
             this.messageListener = messageListener;
             while (!httpCarbonMessage.isEmpty()) {
-                HttpContent httpContent = httpCarbonMessage.getHttpContent();
-                notifyMessageListener(httpContent);
-                if (httpContent instanceof LastHttpContent) {
-                    this.httpCarbonMessage.removeMessageFuture();
-                    return;
-                }
+                httpCarbonMessage.notifyListener();
             }
         }
     }
 
-    void notifyMessageListener(HttpContent httpContent) {
+    public void notifyMessageListener(HttpContent httpContent) {
         if (this.messageListener != null) {
             this.messageListener.onMessage(httpContent);
         } else {


### PR DESCRIPTION
Client can go OOM if the server is slow during a send operation because of data collecting in the netty buffer. Similarly server can go OOM if the client is slow during a respond operation. Outbound throttling fixes this issue.

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/8767